### PR TITLE
Backport: misc: qcom: qdsp6v2: Support hardware accelerated audio effects

### DIFF
--- a/drivers/misc/qcom/qdsp6v2/Makefile
+++ b/drivers/misc/qcom/qdsp6v2/Makefile
@@ -1,5 +1,5 @@
 obj-$(CONFIG_MSM_QDSP6V2_CODECS) += aac_in.o qcelp_in.o evrc_in.o amrnb_in.o audio_utils.o
 obj-$(CONFIG_MSM_QDSP6V2_CODECS) += audio_wma.o audio_wmapro.o audio_aac.o audio_multi_aac.o audio_alac.o audio_ape.o audio_utils_aio.o
 obj-$(CONFIG_MSM_QDSP6V2_CODECS) += q6audio_v2.o q6audio_v2_aio.o
-obj-$(CONFIG_MSM_QDSP6V2_CODECS)  += audio_mp3.o audio_amrnb.o audio_amrwb.o audio_amrwbplus.o audio_evrc.o audio_qcelp.o amrwb_in.o
+obj-$(CONFIG_MSM_QDSP6V2_CODECS)  += audio_mp3.o audio_amrnb.o audio_amrwb.o audio_amrwbplus.o audio_evrc.o audio_qcelp.o amrwb_in.o audio_hwacc_effects.o
 obj-$(CONFIG_MSM_ULTRASOUND) += ultrasound/

--- a/drivers/misc/qcom/qdsp6v2/audio_hwacc_effects.c
+++ b/drivers/misc/qcom/qdsp6v2/audio_hwacc_effects.c
@@ -1,0 +1,728 @@
+/*
+ * Copyright (c) 2014, The Linux Foundation. All rights reserved.
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+
+#include <linux/msm_audio.h>
+#include <linux/compat.h>
+#include "q6audio_common.h"
+#include "audio_utils_aio.h"
+#include <sound/msm-audio-effects-q6-v2.h>
+
+#define MAX_CHANNELS_SUPPORTED		8
+#define MAX_PP_PARAMS_SZ		128
+#define WAIT_TIMEDOUT_DURATION_SECS	1
+
+struct msm_nt_eff_all_config {
+	struct bass_boost_params bass_boost;
+	struct virtualizer_params virtualizer;
+	struct reverb_params reverb;
+	struct eq_params equalizer;
+	struct soft_volume_params saplus_vol;
+	struct soft_volume_params topo_switch_vol;
+};
+
+struct q6audio_effects {
+	wait_queue_head_t		read_wait;
+	wait_queue_head_t		write_wait;
+
+	struct audio_client             *ac;
+	struct msm_hwacc_effects_config  config;
+
+	atomic_t			in_count;
+	atomic_t			out_count;
+
+	int				opened;
+	int				started;
+	int				buf_alloc;
+	struct msm_nt_eff_all_config audio_effects;
+};
+
+static void audio_effects_init_pp(struct audio_client *ac)
+{
+	int ret = 0;
+	struct asm_softvolume_params softvol = {
+		.period = SOFT_VOLUME_PERIOD,
+		.step = SOFT_VOLUME_STEP,
+		.rampingcurve = SOFT_VOLUME_CURVE_LINEAR,
+	};
+
+	if (!ac) {
+		pr_err("%s: audio client null to init pp\n", __func__);
+		return;
+	}
+	/* Add topology specific handling here when needed in future */
+	ret = q6asm_set_softvolume_v2(ac, &softvol,
+				      SOFT_VOLUME_INSTANCE_1);
+	if (ret < 0)
+		pr_err("%s: Send SoftVolume Param failed ret=%d\n",
+			__func__, ret);
+}
+
+static void audio_effects_deinit_pp(struct audio_client *ac)
+{
+	if (!ac) {
+		pr_err("%s: audio client null to deinit pp\n", __func__);
+		return;
+	}
+	/* Add topology specific handling here when needed in future */
+}
+
+static void audio_effects_event_handler(uint32_t opcode, uint32_t token,
+				 uint32_t *payload,  void *priv)
+{
+	struct q6audio_effects *effects;
+
+	if (!payload || !priv) {
+		pr_err("%s: invalid data to handle events, payload: %p, priv: %p\n",
+			__func__, payload, priv);
+		return;
+	}
+
+	effects = (struct q6audio_effects *)priv;
+	switch (opcode) {
+	case ASM_DATA_EVENT_WRITE_DONE_V2: {
+		atomic_inc(&effects->out_count);
+		wake_up(&effects->write_wait);
+		break;
+	}
+	case ASM_DATA_EVENT_READ_DONE_V2: {
+		atomic_inc(&effects->in_count);
+		wake_up(&effects->read_wait);
+		break;
+	}
+	case APR_BASIC_RSP_RESULT: {
+		pr_debug("%s: APR_BASIC_RSP_RESULT Cmd[0x%x] Status[0x%x]\n",
+			 __func__, payload[0], payload[1]);
+		switch (payload[0]) {
+		case ASM_SESSION_CMD_RUN_V2:
+			pr_debug("ASM_SESSION_CMD_RUN_V2\n");
+			break;
+		default:
+			pr_debug("%s: Payload = [0x%x] stat[0x%x]\n",
+				 __func__, payload[0], payload[1]);
+			break;
+		}
+		break;
+	}
+	default:
+		pr_debug("%s: Unhandled Event 0x%x token = 0x%x\n",
+			 __func__, opcode, token);
+		break;
+	}
+}
+
+static int audio_effects_shared_ioctl(struct file *file, unsigned cmd,
+				      unsigned long arg)
+{
+	struct q6audio_effects *effects = file->private_data;
+	int rc = 0;
+	switch (cmd) {
+	case AUDIO_START: {
+		pr_debug("%s: AUDIO_START\n", __func__);
+
+		rc = q6asm_open_read_write_v2(effects->ac,
+					FORMAT_LINEAR_PCM,
+					FORMAT_MULTI_CHANNEL_LINEAR_PCM,
+					effects->config.meta_mode_enabled,
+					effects->config.output.bits_per_sample,
+					effects->config.overwrite_topology,
+					effects->config.topology);
+		if (rc < 0) {
+			pr_err("%s: Open failed for hw accelerated effects:rc=%d\n",
+				__func__, rc);
+			rc = -EINVAL;
+			goto ioctl_fail;
+		}
+		effects->opened = 1;
+
+		pr_debug("%s: dec buf size: %d, num_buf: %d, enc buf size: %d, num_buf: %d\n",
+			 __func__, effects->config.output.buf_size,
+			 effects->config.output.buf_size,
+			 effects->config.input.buf_size,
+			 effects->config.input.num_buf);
+		rc = q6asm_audio_client_buf_alloc_contiguous(IN, effects->ac,
+					effects->config.output.buf_size,
+					effects->config.output.num_buf);
+		if (rc < 0) {
+			pr_err("%s: Write buffer Allocation failed rc = %d\n",
+				__func__, rc);
+			rc = -ENOMEM;
+			goto ioctl_fail;
+		}
+		atomic_set(&effects->in_count, effects->config.input.num_buf);
+		rc = q6asm_audio_client_buf_alloc_contiguous(OUT, effects->ac,
+					effects->config.input.buf_size,
+					effects->config.input.num_buf);
+		if (rc < 0) {
+			pr_err("%s: Read buffer Allocation failed rc = %d\n",
+				__func__, rc);
+			rc = -ENOMEM;
+			goto readbuf_fail;
+		}
+		atomic_set(&effects->out_count, effects->config.output.num_buf);
+		effects->buf_alloc = 1;
+
+		pr_debug("%s: enc: sample_rate: %d, num_channels: %d\n",
+			 __func__, effects->config.input.sample_rate,
+			effects->config.input.num_channels);
+		rc = q6asm_enc_cfg_blk_pcm(effects->ac,
+					   effects->config.input.sample_rate,
+					   effects->config.input.num_channels);
+		if (rc < 0) {
+			pr_err("%s: pcm read block config failed\n", __func__);
+			rc = -EINVAL;
+			goto cfg_fail;
+		}
+		pr_debug("%s: dec: sample_rate: %d, num_channels: %d, bit_width: %d\n",
+			 __func__, effects->config.output.sample_rate,
+			effects->config.output.num_channels,
+			effects->config.output.bits_per_sample);
+		rc = q6asm_media_format_block_pcm_format_support(
+				effects->ac, effects->config.output.sample_rate,
+				effects->config.output.num_channels,
+				effects->config.output.bits_per_sample);
+		if (rc < 0) {
+			pr_err("%s: pcm write format block config failed\n",
+				__func__);
+			rc = -EINVAL;
+			goto cfg_fail;
+		}
+
+		audio_effects_init_pp(effects->ac);
+
+		rc = q6asm_run(effects->ac, 0x00, 0x00, 0x00);
+		if (!rc)
+			effects->started = 1;
+		else {
+			effects->started = 0;
+			pr_err("%s: ASM run state failed\n", __func__);
+		}
+		break;
+	}
+	case AUDIO_EFFECTS_WRITE: {
+		char *bufptr = NULL;
+		uint32_t idx = 0;
+		uint32_t size = 0;
+
+		if (!effects->started) {
+			rc = -EFAULT;
+			goto ioctl_fail;
+		}
+
+		rc = wait_event_timeout(effects->write_wait,
+					atomic_read(&effects->out_count),
+					WAIT_TIMEDOUT_DURATION_SECS * HZ);
+		if (!rc) {
+			pr_err("%s: write wait_event_timeout\n", __func__);
+			rc = -EFAULT;
+			goto ioctl_fail;
+		}
+		if (!atomic_read(&effects->out_count)) {
+			pr_err("%s: pcm stopped out_count 0\n", __func__);
+			rc = -EFAULT;
+			goto ioctl_fail;
+		}
+
+		bufptr = q6asm_is_cpu_buf_avail(IN, effects->ac, &size, &idx);
+		if (bufptr) {
+			if (copy_from_user(bufptr, (void *)arg,
+					effects->config.buf_cfg.output_len)) {
+				rc = -EFAULT;
+				goto ioctl_fail;
+			}
+			rc = q6asm_write(effects->ac,
+					 effects->config.buf_cfg.output_len,
+					 0, 0, NO_TIMESTAMP);
+			if (rc < 0) {
+				rc = -EFAULT;
+				goto ioctl_fail;
+			}
+			atomic_dec(&effects->out_count);
+		} else {
+			pr_err("%s: AUDIO_EFFECTS_WRITE: Buffer dropped\n",
+				__func__);
+		}
+		break;
+	}
+	case AUDIO_EFFECTS_READ: {
+		char *bufptr = NULL;
+		uint32_t idx = 0;
+		uint32_t size = 0;
+
+		if (!effects->started) {
+			rc = -EFAULT;
+			goto ioctl_fail;
+		}
+
+		atomic_set(&effects->in_count, 0);
+
+		q6asm_read_v2(effects->ac, effects->config.buf_cfg.input_len);
+		/* Read might fail initially, don't error out */
+		if (rc < 0)
+			pr_err("%s: read failed\n", __func__);
+
+		rc = wait_event_timeout(effects->read_wait,
+					atomic_read(&effects->in_count),
+					WAIT_TIMEDOUT_DURATION_SECS * HZ);
+		if (!rc) {
+			pr_err("%s: read wait_event_timeout\n", __func__);
+			rc = -EFAULT;
+			goto ioctl_fail;
+		}
+		if (!atomic_read(&effects->in_count)) {
+			pr_err("%s: pcm stopped in_count 0\n", __func__);
+			rc = -EFAULT;
+			goto ioctl_fail;
+		}
+
+		bufptr = q6asm_is_cpu_buf_avail(OUT, effects->ac, &size, &idx);
+		if (bufptr) {
+			if (!((void *)arg)) {
+				rc = -EFAULT;
+				goto ioctl_fail;
+			}
+			if (copy_to_user((void *)arg, bufptr,
+					  effects->config.buf_cfg.input_len)) {
+				rc = -EFAULT;
+				goto ioctl_fail;
+			}
+		}
+		break;
+	}
+	default:
+		pr_err("%s: Invalid effects config module\n", __func__);
+		rc = -EINVAL;
+		break;
+	}
+ioctl_fail:
+	return rc;
+readbuf_fail:
+	q6asm_audio_client_buf_free_contiguous(IN,
+					effects->ac);
+	return rc;
+cfg_fail:
+	q6asm_audio_client_buf_free_contiguous(IN,
+					effects->ac);
+	q6asm_audio_client_buf_free_contiguous(OUT,
+					effects->ac);
+	effects->buf_alloc = 0;
+	return rc;
+}
+
+static long audio_effects_set_pp_param(struct q6audio_effects *effects,
+				long *values)
+{
+	int rc = 0;
+	int effects_module = values[0];
+	switch (effects_module) {
+	case VIRTUALIZER_MODULE:
+		pr_debug("%s: VIRTUALIZER_MODULE\n", __func__);
+		if (msm_audio_effects_is_effmodule_supp_in_top(
+			effects_module, effects->ac->topology))
+			msm_audio_effects_virtualizer_handler(
+				effects->ac,
+				&(effects->audio_effects.virtualizer),
+				(long *)&values[1]);
+		break;
+	case REVERB_MODULE:
+		pr_debug("%s: REVERB_MODULE\n", __func__);
+		if (msm_audio_effects_is_effmodule_supp_in_top(
+			effects_module, effects->ac->topology))
+			msm_audio_effects_reverb_handler(effects->ac,
+				 &(effects->audio_effects.reverb),
+				 (long *)&values[1]);
+		break;
+	case BASS_BOOST_MODULE:
+		pr_debug("%s: BASS_BOOST_MODULE\n", __func__);
+		if (msm_audio_effects_is_effmodule_supp_in_top(
+			effects_module, effects->ac->topology))
+			msm_audio_effects_bass_boost_handler(
+				effects->ac,
+				&(effects->audio_effects.bass_boost),
+				(long *)&values[1]);
+		break;
+	case EQ_MODULE:
+		pr_debug("%s: EQ_MODULE\n", __func__);
+		if (msm_audio_effects_is_effmodule_supp_in_top(
+			effects_module, effects->ac->topology))
+			msm_audio_effects_popless_eq_handler(
+				effects->ac,
+				&(effects->audio_effects.equalizer),
+				(long *)&values[1]);
+		break;
+	case SOFT_VOLUME_MODULE:
+		pr_debug("%s: SA PLUS VOLUME_MODULE\n", __func__);
+		msm_audio_effects_volume_handler_v2(effects->ac,
+				&(effects->audio_effects.saplus_vol),
+				(long *)&values[1], SOFT_VOLUME_INSTANCE_1);
+		break;
+	case SOFT_VOLUME2_MODULE:
+		pr_debug("%s: TOPOLOGY SWITCH VOLUME MODULE\n",
+			 __func__);
+		if (msm_audio_effects_is_effmodule_supp_in_top(
+			effects_module, effects->ac->topology))
+			msm_audio_effects_volume_handler_v2(effects->ac,
+			      &(effects->audio_effects.topo_switch_vol),
+			      (long *)&values[1], SOFT_VOLUME_INSTANCE_2);
+		break;
+	default:
+		pr_err("%s: Invalid effects config module\n", __func__);
+		rc = -EINVAL;
+	}
+	return rc;
+}
+
+static long audio_effects_ioctl(struct file *file, unsigned int cmd,
+				unsigned long arg)
+{
+	struct q6audio_effects *effects = file->private_data;
+	int rc = 0;
+	long argvalues[MAX_PP_PARAMS_SZ] = {0};
+
+	switch (cmd) {
+	case AUDIO_SET_EFFECTS_CONFIG: {
+		pr_debug("%s: AUDIO_SET_EFFECTS_CONFIG\n", __func__);
+		memset(&effects->config, 0, sizeof(effects->config));
+		if (copy_from_user(&effects->config, (void *)arg,
+				   sizeof(effects->config))) {
+			pr_err("%s: copy from user for AUDIO_SET_EFFECTS_CONFIG failed\n",
+				__func__);
+			rc = -EFAULT;
+		}
+		pr_debug("%s: write buf_size: %d, num_buf: %d, sample_rate: %d, channel: %d\n",
+			 __func__, effects->config.output.buf_size,
+			 effects->config.output.num_buf,
+			 effects->config.output.sample_rate,
+			 effects->config.output.num_channels);
+		pr_debug("%s: read buf_size: %d, num_buf: %d, sample_rate: %d, channel: %d\n",
+			 __func__, effects->config.input.buf_size,
+			 effects->config.input.num_buf,
+			 effects->config.input.sample_rate,
+			 effects->config.input.num_channels);
+		break;
+	}
+	case AUDIO_EFFECTS_SET_BUF_LEN: {
+		if (copy_from_user(&effects->config.buf_cfg, (void *)arg,
+				   sizeof(effects->config.buf_cfg))) {
+			pr_err("%s: copy from user for AUDIO_EFFECTS_SET_BUF_LEN failed\n",
+				__func__);
+			rc = -EFAULT;
+		}
+		pr_debug("%s: write buf len: %d, read buf len: %d\n",
+			 __func__, effects->config.buf_cfg.output_len,
+			 effects->config.buf_cfg.input_len);
+		break;
+	}
+	case AUDIO_EFFECTS_GET_BUF_AVAIL: {
+		struct msm_hwacc_buf_avail buf_avail;
+
+		buf_avail.input_num_avail = atomic_read(&effects->in_count);
+		buf_avail.output_num_avail = atomic_read(&effects->out_count);
+		pr_debug("%s: write buf avail: %d, read buf avail: %d\n",
+			 __func__, buf_avail.output_num_avail,
+			 buf_avail.input_num_avail);
+		if (copy_to_user((void *)arg, &buf_avail,
+				   sizeof(buf_avail))) {
+			pr_err("%s: copy to user for AUDIO_EFFECTS_GET_NUM_BUF_AVAIL failed\n",
+				__func__);
+			rc = -EFAULT;
+		}
+		break;
+	}
+	case AUDIO_EFFECTS_SET_PP_PARAMS: {
+		if (copy_from_user(argvalues, (void *)arg,
+				   MAX_PP_PARAMS_SZ*sizeof(long))) {
+			pr_err("%s: copy from user for pp params failed\n",
+				__func__);
+			return -EFAULT;
+		}
+		rc = audio_effects_set_pp_param(effects, argvalues);
+		break;
+	}
+	default:
+		pr_debug("%s: Calling shared ioctl\n", __func__);
+		rc = audio_effects_shared_ioctl(file, cmd, arg);
+		break;
+	}
+	if (rc)
+		pr_err("%s: cmd 0x%x failed\n", __func__, cmd);
+	return rc;
+}
+
+#ifdef CONFIG_COMPAT
+struct msm_hwacc_data_config32 {
+	__u32 buf_size;
+	__u32 num_buf;
+	__u32 num_channels;
+	__u8 channel_map[MAX_CHANNELS_SUPPORTED];
+	__u32 sample_rate;
+	__u32 bits_per_sample;
+};
+
+struct msm_hwacc_buf_cfg32 {
+	__u32 input_len;
+	__u32 output_len;
+};
+
+struct msm_hwacc_buf_avail32 {
+	__u32 input_num_avail;
+	__u32 output_num_avail;
+};
+
+struct msm_hwacc_effects_config32 {
+	struct msm_hwacc_data_config32 input;
+	struct msm_hwacc_data_config32 output;
+	struct msm_hwacc_buf_cfg32 buf_cfg;
+	__u32 meta_mode_enabled;
+	__u32 overwrite_topology;
+	__s32 topology;
+};
+
+enum {
+	AUDIO_SET_EFFECTS_CONFIG32 = _IOW(AUDIO_IOCTL_MAGIC, 99,
+					  struct msm_hwacc_effects_config32),
+	AUDIO_EFFECTS_SET_BUF_LEN32 = _IOW(AUDIO_IOCTL_MAGIC, 100,
+					   struct msm_hwacc_buf_cfg32),
+	AUDIO_EFFECTS_GET_BUF_AVAIL32 = _IOW(AUDIO_IOCTL_MAGIC, 101,
+					     struct msm_hwacc_buf_avail32),
+	AUDIO_EFFECTS_WRITE32 = _IOW(AUDIO_IOCTL_MAGIC, 102, compat_uptr_t),
+	AUDIO_EFFECTS_READ32 = _IOWR(AUDIO_IOCTL_MAGIC, 103, compat_uptr_t),
+	AUDIO_EFFECTS_SET_PP_PARAMS32 = _IOW(AUDIO_IOCTL_MAGIC, 104,
+					   compat_uptr_t),
+	AUDIO_START32 = _IOW(AUDIO_IOCTL_MAGIC, 0, unsigned),
+};
+
+static long audio_effects_compat_ioctl(struct file *file, unsigned int cmd,
+					unsigned long arg)
+{
+	struct q6audio_effects *effects = file->private_data;
+	int rc = 0, i;
+
+	switch (cmd) {
+	case AUDIO_SET_EFFECTS_CONFIG32: {
+		struct msm_hwacc_effects_config32 config32;
+		struct msm_hwacc_effects_config *config = &effects->config;
+		memset(&effects->config, 0, sizeof(effects->config));
+		if (copy_from_user(&config32, (void *)arg,
+				   sizeof(config32))) {
+			pr_err("%s: copy to user for AUDIO_SET_EFFECTS_CONFIG failed\n",
+				__func__);
+			rc = -EFAULT;
+			break;
+		}
+		config->input.buf_size = config32.input.buf_size;
+		config->input.num_buf = config32.input.num_buf;
+		config->input.num_channels = config32.input.num_channels;
+		config->input.sample_rate = config32.input.sample_rate;
+		config->input.bits_per_sample = config32.input.bits_per_sample;
+		config->input.buf_size = config32.input.buf_size;
+		for (i = 0; i < MAX_CHANNELS_SUPPORTED; i++)
+			config->input.channel_map[i] =
+						config32.input.channel_map[i];
+		config->output.buf_size = config32.output.buf_size;
+		config->output.num_buf = config32.output.num_buf;
+		config->output.num_channels = config32.output.num_channels;
+		config->output.sample_rate = config32.output.sample_rate;
+		config->output.bits_per_sample =
+					 config32.output.bits_per_sample;
+		config->output.buf_size = config32.output.buf_size;
+		for (i = 0; i < MAX_CHANNELS_SUPPORTED; i++)
+			config->output.channel_map[i] =
+						config32.output.channel_map[i];
+		config->buf_cfg.input_len = config32.buf_cfg.input_len;
+		config->buf_cfg.output_len = config32.buf_cfg.output_len;
+		config->meta_mode_enabled = config32.meta_mode_enabled;
+		config->overwrite_topology = config32.overwrite_topology;
+		config->topology = config32.topology;
+		pr_debug("%s: write buf_size: %d, num_buf: %d, sample_rate: %d, channels: %d\n",
+			 __func__, effects->config.output.buf_size,
+			 effects->config.output.num_buf,
+			 effects->config.output.sample_rate,
+			 effects->config.output.num_channels);
+		pr_debug("%s: read buf_size: %d, num_buf: %d, sample_rate: %d, channels: %d\n",
+			 __func__, effects->config.input.buf_size,
+			 effects->config.input.num_buf,
+			 effects->config.input.sample_rate,
+			 effects->config.input.num_channels);
+		break;
+	}
+	case AUDIO_EFFECTS_SET_BUF_LEN32: {
+		struct msm_hwacc_buf_cfg32 buf_cfg32;
+		struct msm_hwacc_effects_config *config = &effects->config;
+		if (copy_from_user(&buf_cfg32, (void *)arg,
+				   sizeof(buf_cfg32))) {
+			pr_err("%s: copy from user for AUDIO_EFFECTS_SET_BUF_LEN failed\n",
+				__func__);
+			rc = -EFAULT;
+			break;
+		}
+		config->buf_cfg.input_len = buf_cfg32.input_len;
+		config->buf_cfg.output_len = buf_cfg32.output_len;
+		pr_debug("%s: write buf len: %d, read buf len: %d\n",
+			 __func__, effects->config.buf_cfg.output_len,
+			 effects->config.buf_cfg.input_len);
+		break;
+	}
+	case AUDIO_EFFECTS_GET_BUF_AVAIL32: {
+		struct msm_hwacc_buf_avail32 buf_avail;
+
+		buf_avail.input_num_avail = atomic_read(&effects->in_count);
+		buf_avail.output_num_avail = atomic_read(&effects->out_count);
+		pr_debug("%s: write buf avail: %d, read buf avail: %d\n",
+			 __func__, buf_avail.output_num_avail,
+			 buf_avail.input_num_avail);
+		if (copy_to_user((void *)arg, &buf_avail,
+				   sizeof(buf_avail))) {
+			pr_err("%s: copy to user for AUDIO_EFFECTS_GET_NUM_BUF_AVAIL failed\n",
+				__func__);
+			rc = -EFAULT;
+		}
+		break;
+	}
+	case AUDIO_EFFECTS_SET_PP_PARAMS32: {
+		long argvalues[MAX_PP_PARAMS_SZ] = {0};
+		int argvalues32[MAX_PP_PARAMS_SZ] = {0};
+
+		if (copy_from_user(argvalues32, (void *)arg,
+				   MAX_PP_PARAMS_SZ*sizeof(int))) {
+			pr_err("%s: copy from user failed for pp params\n",
+				__func__);
+			return -EFAULT;
+		}
+		for (i = 0; i < MAX_PP_PARAMS_SZ; i++)
+			argvalues[i] = argvalues32[i];
+
+		rc = audio_effects_set_pp_param(effects, argvalues);
+		break;
+	}
+	case AUDIO_START32: {
+		rc = audio_effects_shared_ioctl(file, AUDIO_START, arg);
+		break;
+	}
+	case AUDIO_EFFECTS_WRITE32: {
+		rc = audio_effects_shared_ioctl(file, AUDIO_EFFECTS_WRITE, arg);
+		break;
+	}
+	case AUDIO_EFFECTS_READ32: {
+		rc = audio_effects_shared_ioctl(file, AUDIO_EFFECTS_READ, arg);
+		break;
+	}
+	default:
+		pr_debug("%s: unhandled ioctl\n", __func__);
+		rc = -EINVAL;
+		break;
+	}
+	return rc;
+}
+#endif
+
+static int audio_effects_release(struct inode *inode, struct file *file)
+{
+	struct q6audio_effects *effects = file->private_data;
+	int rc = 0;
+	if (!effects) {
+		pr_err("%s: effect is NULL\n", __func__);
+		return -EINVAL;
+	}
+	if (effects->opened) {
+		rc = wait_event_timeout(effects->write_wait,
+					atomic_read(&effects->out_count),
+					WAIT_TIMEDOUT_DURATION_SECS * HZ);
+		if (!rc)
+			pr_err("%s: write wait_event_timeout failed\n",
+				__func__);
+		rc = wait_event_timeout(effects->read_wait,
+					atomic_read(&effects->in_count),
+					WAIT_TIMEDOUT_DURATION_SECS * HZ);
+		if (!rc)
+			pr_err("%s: read wait_event_timeout failed\n",
+				__func__);
+		rc = q6asm_cmd(effects->ac, CMD_CLOSE);
+		if (rc < 0)
+			pr_err("%s[%p]:Failed to close the session rc=%d\n",
+				__func__, effects, rc);
+		effects->opened = 0;
+		effects->started = 0;
+
+		audio_effects_deinit_pp(effects->ac);
+	}
+
+	if (effects->buf_alloc) {
+		q6asm_audio_client_buf_free_contiguous(IN, effects->ac);
+		q6asm_audio_client_buf_free_contiguous(OUT, effects->ac);
+	}
+	q6asm_audio_client_free(effects->ac);
+
+	kfree(effects);
+
+	pr_debug("%s: close session success\n", __func__);
+	return rc;
+}
+
+static int audio_effects_open(struct inode *inode, struct file *file)
+{
+	struct q6audio_effects *effects;
+	int rc = 0;
+
+	effects = kzalloc(sizeof(struct q6audio_effects), GFP_KERNEL);
+	if (!effects) {
+		pr_err("%s: Could not allocate memory for hw acc effects driver\n",
+			__func__);
+		return -ENOMEM;
+	}
+
+	effects->ac = q6asm_audio_client_alloc(
+					(app_cb)audio_effects_event_handler,
+					(void *)effects);
+	if (!effects->ac) {
+		pr_err("%s: Could not allocate memory for audio client\n",
+			__func__);
+		kfree(effects);
+		return -ENOMEM;
+	}
+
+	init_waitqueue_head(&effects->read_wait);
+	init_waitqueue_head(&effects->write_wait);
+
+	effects->opened = 0;
+	effects->started = 0;
+	effects->buf_alloc = 0;
+	file->private_data = effects;
+	pr_debug("%s: open session success\n", __func__);
+	return rc;
+}
+
+static const struct file_operations audio_effects_fops = {
+	.owner = THIS_MODULE,
+	.open = audio_effects_open,
+	.release = audio_effects_release,
+	.unlocked_ioctl = audio_effects_ioctl,
+#ifdef CONFIG_COMPAT
+	.compat_ioctl = audio_effects_compat_ioctl,
+#endif
+};
+
+struct miscdevice audio_effects_misc = {
+	.minor = MISC_DYNAMIC_MINOR,
+	.name = "msm_hweffects",
+	.fops = &audio_effects_fops,
+};
+
+static int __init audio_effects_init(void)
+{
+	return misc_register(&audio_effects_misc);
+}
+
+device_initcall(audio_effects_init);
+MODULE_DESCRIPTION("Audio hardware accelerated effects driver");
+MODULE_LICENSE("GPL v2");

--- a/include/uapi/linux/msm_audio.h
+++ b/include/uapi/linux/msm_audio.h
@@ -1,7 +1,7 @@
 /* include/linux/msm_audio.h
  *
  * Copyright (C) 2008 Google, Inc.
- * Copyright (c) 2012 The Linux Foundation. All rights reserved.
+ * Copyright (c) 2012, 2014 The Linux Foundation. All rights reserved.
  *
  * This software is licensed under the terms of the GNU General Public
  * License version 2, as published by the Free Software Foundation, and
@@ -104,8 +104,17 @@
 		struct msm_audio_ion_info)
 #define AUDIO_DEREGISTER_ION _IOW(AUDIO_IOCTL_MAGIC, 98, \
 		struct msm_audio_ion_info)
+#define AUDIO_SET_EFFECTS_CONFIG   _IOW(AUDIO_IOCTL_MAGIC, 99, \
+				struct msm_hwacc_effects_config)
+#define AUDIO_EFFECTS_SET_BUF_LEN _IOW(AUDIO_IOCTL_MAGIC, 100, \
+				struct msm_hwacc_buf_cfg)
+#define AUDIO_EFFECTS_GET_BUF_AVAIL _IOW(AUDIO_IOCTL_MAGIC, 101, \
+				struct msm_hwacc_buf_avail)
+#define AUDIO_EFFECTS_WRITE _IOW(AUDIO_IOCTL_MAGIC, 102, void *)
+#define AUDIO_EFFECTS_READ _IOWR(AUDIO_IOCTL_MAGIC, 103, void *)
+#define AUDIO_EFFECTS_SET_PP_PARAMS _IOW(AUDIO_IOCTL_MAGIC, 104, void *)
 
-#define	AUDIO_MAX_COMMON_IOCTL_NUM	100
+#define	AUDIO_MAX_COMMON_IOCTL_NUM	105
 
 
 #define HANDSET_MIC			0x01
@@ -140,7 +149,7 @@
 #define I2S_TX				0x21
 
 #define ADRC_ENABLE		0x0001
-#define EQ_ENABLE		0x0002
+#define EQUALIZER_ENABLE	0x0002
 #define IIR_ENABLE		0x0004
 #define QCONCERT_PLUS_ENABLE	0x0008
 #define MBADRC_ENABLE		0x0010
@@ -420,5 +429,32 @@ struct msm_acdb_cmd_device {
 	uint32_t     *phys_buf;           /* Physical Address of data */
 };
 
+struct msm_hwacc_data_config {
+	__u32 buf_size;
+	__u32 num_buf;
+	__u32 num_channels;
+	__u8 channel_map[8];
+	__u32 sample_rate;
+	__u32 bits_per_sample;
+};
+
+struct msm_hwacc_buf_cfg {
+	__u32 input_len;
+	__u32 output_len;
+};
+
+struct msm_hwacc_buf_avail {
+	__u32 input_num_avail;
+	__u32 output_num_avail;
+};
+
+struct msm_hwacc_effects_config {
+	struct msm_hwacc_data_config input;
+	struct msm_hwacc_data_config output;
+	struct msm_hwacc_buf_cfg buf_cfg;
+	__u32 meta_mode_enabled;
+	__u32 overwrite_topology;
+	__s32 topology;
+};
 
 #endif


### PR DESCRIPTION
From: https://source.codeaurora.org/quic/la/kernel/msm-3.10/patch/?id=5e200262f8432b1ea16879ca5c3378ec3547d02a&h=LA.BR.1.2.9.1-02310-8x16.0

Fixes:
```
[  0% 568/84801] target thumb C: libqcompostprocbundle_32 <= hardware/qcom/audio-caf/msm8916/post_proc/bundle.c
FAILED: /mnt/packages/lineageos/out/target/product/idol3/obj_arm/SHARED_LIBRARIES/libqcompostprocbundle_intermediates/bundle.o
/bin/bash -c "PWD=/proc/self/cwd /usr/bin/ccache prebuilts/clang/host/linux-x86/clang-4053586/bin/clang         -I device/alcatel/idol3/include -I external/tinyalsa/include -I /mnt/packages/lineageos/out/target/product/idol3/obj/KERNEL_OBJ/usr/include -I system/media/audio_effects/include -I hardware/qcom/audio-caf/msm8916/post_proc -I /mnt/packages/lineageos/out/target/product/idol3/obj_arm/SHARED_LIBRARIES/libqcompostprocbundle_intermediates -I /mnt/packages/lineageos/out/target/product/idol3/gen/SHARED_LIBRARIES/libqcompostprocbundle_intermediates -I libnativehelper/include_deprecated \$(cat /mnt/packages/lineageos/out/target/product/idol3/obj_arm/SHARED_LIBRARIES/libqcompostprocbundle_intermediates/import_includes)  -I system/core/include -I system/media/audio/include -I hardware/libhardware/include -I hardware/libhardware_legacy/include -I hardware/ril/include -I libnativehelper/include -I frameworks/native/include -I frameworks/native/opengl/include -I frameworks/av/include -isystem /mnt/packages/lineageos/out/target/product/idol3/obj/include -isystem bionic/libc/arch-arm/include -isystem bionic/libc/include -isystem bionic/libc/kernel/uapi -isystem bionic/libc/kernel/uapi/asm-arm -isystem bionic/libc/kernel/android/scsi -isystem bionic/libc/kernel/android/uapi -c  -fno-exceptions -Wno-multichar -ffunction-sections -fdata-sections -funwind-tables -fstack-protector-strong -Wa,--noexecstack -Werror=format-security -D_FORTIFY_SOURCE=2 -fno-short-enums -no-canonical-prefixes -DNDEBUG -g -Wstrict-aliasing=2 -DANDROID -fmessage-length=0 -W -Wall -Wno-unused -Winit-self -Wpointer-arith -DNDEBUG -UDEBUG -fdebug-prefix-map=/proc/self/cwd= -D__compiler_offsetof=__builtin_offsetof -Werror=int-conversion -Wno-reserved-id-macro -Wno-format-pedantic -Wno-unused-command-line-argument -fcolor-diagnostics -Wno-expansion-to-defined -fdebug-prefix-map=\$PWD/= -Werror=return-type -Werror=non-virtual-dtor -Werror=address -Werror=sequence-point -Werror=date-time -nostdlibinc -msoft-float -mfloat-abi=softfp -mfpu=neon -mcpu=cortex-a53 -mfpu=neon-fp-armv8 -D__ARM_FEATURE_LPAE=1 -target arm-linux-androideabi -Bprebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.9/arm-linux-androideabi/bin   -std=gnu99 -mthumb -Os -fomit-frame-pointer -fno-strict-aliasing   -DAFE_PROXY_ENABLED -O2 -fvisibility=hidden -DPLATFORM_MSM8916 -fPIC -D_USING_LIBCXX -DANDROID_STRICT   -Werror=int-to-pointer-cast -Werror=pointer-to-int-cast -Werror=address-of-temporary -Werror=return-type   -MD -MF /mnt/packages/lineageos/out/target/product/idol3/obj_arm/SHARED_LIBRARIES/libqcompostprocbundle_intermediates/bundle.d -o /mnt/packages/lineageos/out/target/product/idol3/obj_arm/SHARED_LIBRARIES/libqcompostprocbundle_intermediates/bundle.o hardware/qcom/audio-caf/msm8916/post_proc/bundle.c"
In file included from hardware/qcom/audio-caf/msm8916/post_proc/bundle.c:48:
In file included from hardware/qcom/audio-caf/msm8916/post_proc/hw_accelerator.h:36:
out/target/product/idol3/obj/KERNEL_OBJ/usr/include/linux/msm_audio.h:143:9: warning: 'EQ_ENABLE' macro redefined [-Wmacro-redefined]
#define EQ_ENABLE               0x0002
        ^
out/target/product/idol3/obj/KERNEL_OBJ/usr/include/sound/audio_effects.h:102:9: note: previous definition is here
#define EQ_ENABLE                       0x00004001
        ^

```


Audio post processing features such as HeadphoneX are supported
only in DSP. To apply post processing for the playback which is
not routed through DSP, effects are applied through hardware
accelerated mode where PCM samples are sent to DSP for effects
processing in write path and captured by userspace through read
path.

Change-Id: I50272b04586770136bc48ba231eef1eac81387c5
Signed-off-by: Subhash Chandra Bose Naripeddy <snariped@codeaurora.org>
Signed-off-by: Alexy Joseph <alexyj@codeaurora.org>