### PR TITLE
fix "multiple definition of 'yylloc'"

### DIFF
--- a/scripts/dtc/dtc-lexer.lex.c_shipped
+++ b/scripts/dtc/dtc-lexer.lex.c_shipped
@@ -637,7 +637,7 @@ char *yytext;
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-YYLTYPE yylloc;
+extern YYLTYPE yylloc;
 
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
 #define	YY_USER_ACTION \


### PR DESCRIPTION
When building latest lineage-15.1

Fix from: https://forum.xda-developers.com/t/multiple-definitions-in-dtc-error-when-trying-to-build-android-kernel.4123549/post-82951315