### PR TITLE
compilation fixes when building idol347

### DIFF
--- a/arch/arm/include/asm/unistd.h
+++ b/arch/arm/include/asm/unistd.h
@@ -19,7 +19,7 @@
  * This may need to be greater than __NR_last_syscall+1 in order to
  * account for the padding in the syscall table
  */
-#define __NR_syscalls  (385)
+#define __NR_syscalls  (388)
 
 /*
  * *NOTE*: This is a ghost syscall private to the kernel.  Only the

--- a/drivers/staging/android/binder.c
+++ b/drivers/staging/android/binder.c
@@ -2095,7 +2095,7 @@ static void binder_transaction(struct binder_proc *proc,
 	if (!IS_ALIGNED(extra_buffers_size, sizeof(u64))) {
 		binder_user_error("%d:%d got transaction with unaligned buffers size, %lld\n",
 				  proc->pid, thread->pid,
-				  extra_buffers_size);
+				  (u64)extra_buffers_size);
 		return_error = BR_FAILED_REPLY;
 		goto err_bad_offset;
 	}

--- a/drivers/video/msm/mdss/mdss_fb.c
+++ b/drivers/video/msm/mdss/mdss_fb.c
@@ -1455,6 +1455,8 @@ static int mdss_fb_blank_unblank(struct msm_fb_data_type *mfd)
 			 */
 			mfd->allow_bl_update = false;
 		}
+		mutex_unlock(&mfd->bl_lock);
+	}
 	#endif
 error:
 	return ret;

--- a/lib/random32.c
+++ b/lib/random32.c
@@ -38,6 +38,7 @@
 #include <linux/export.h>
 #include <linux/jiffies.h>
 #include <linux/random.h>
+#include <linux/sched.h>
 
 static DEFINE_PER_CPU(struct rnd_state, net_rand_state);
 


### PR DESCRIPTION
Fixes these errors when building with idol347_defconfig (for arm 32bits)
```
/#    _  __                 _   ___ _
/#   | |/ /___ _ _ _ _  ___| | | __(_)_ _____ ___
/#   | ' </ -_) '_| ' \/ -_) | | _|| \ \ / -_|_-<
/#   |_|\_\___|_| |_||_\___|_| |_| |_/_\_\___/__/
/#

../../../../../../kernel/alcatel/msm8916,CarlosArriagaCM/arch/arm/kernel/entry-common.S: Assembler messages:
../../../../../../kernel/alcatel/msm8916,CarlosArriagaCM/arch/arm/kernel/entry-common.S:105: Error: __NR_syscalls is not equal to the size of the syscall table
make[2]: *** [/mnt/packages/lineageos/kernel/alcatel/msm8916,CarlosArriagaCM/scripts/Makefile.build:344: arch/arm/kernel/entry-common.o] Error 1
make[1]: *** [/mnt/packages/lineageos/kernel/alcatel/msm8916,CarlosArriagaCM/Makefile:829: arch/arm/kernel] Error 2
make[1]: *** Waiting for unfinished jobs....

--- a/arch/arm/include/asm/unistd.h
+++ b/arch/arm/include/asm/unistd.h
@@ -19,7 +19,7 @@
  * This may need to be greater than __NR_last_syscall+1 in order to
  * account for the padding in the syscall table
  */
-#define __NR_syscalls  (385)
+#define __NR_syscalls  (388)

 /*
  * *NOTE*: This is a ghost syscall private to the kernel.  Only the

/#    _  __                 _   ___ _
/#   | |/ /___ _ _ _ _  ___| | | __(_)_ _____ ___
/#   | ' </ -_) '_| ' \/ -_) | | _|| \ \ / -_|_-<
/#   |_|\_\___|_| |_||_\___|_| |_| |_/_\_\___/__/
/#

../../../../../../kernel/alcatel/msm8916,CarlosArriagaCM/drivers/staging/android/binder.c: In function 'binder_transaction':
../../../../../../kernel/alcatel/msm8916,CarlosArriagaCM/drivers/staging/android/binder.c:2096:3: warning: format '%lld' expects argument of type 'long long int', but argument 4 has type 'binder_size_t' [-Wformat=]
error, forbidden warning: binder.c:2096
make[4]: *** [/mnt/packages/lineageos/kernel/alcatel/msm8916,CarlosArriagaCM/scripts/Makefile.build:308: drivers/staging/android/binder.o] Error 1
make[3]: *** [/mnt/packages/lineageos/kernel/alcatel/msm8916,CarlosArriagaCM/scripts/Makefile.build:455: drivers/staging/android] Error 2
make[2]: *** [/mnt/packages/lineageos/kernel/alcatel/msm8916,CarlosArriagaCM/scripts/Makefile.build:455: drivers/staging] Error 2
make[2]: *** Waiting for unfinished jobs....

--- a/drivers/staging/android/binder.c
+++ b/drivers/staging/android/binder.c
@@ -2095,7 +2095,7 @@ static void binder_transaction(struct binder_proc *proc,
        if (!IS_ALIGNED(extra_buffers_size, sizeof(u64))) {
                binder_user_error("%d:%d got transaction with unaligned buffers size, %lld\n",
                                  proc->pid, thread->pid,
-                                 extra_buffers_size);
+                                 (u64)extra_buffers_size);
                return_error = BR_FAILED_REPLY;
                goto err_bad_offset;
        }

/#    _  __                 _   ___ _
/#   | |/ /___ _ _ _ _  ___| | | __(_)_ _____ ___
/#   | ' </ -_) '_| ' \/ -_) | | _|| \ \ / -_|_-<
/#   |_|\_\___|_| |_||_\___|_| |_| |_/_\_\___/__/
/#

/mnt/packages/lineageos/kernel/alcatel/msm8916,CarlosArriagaCM/drivers/video/msm/mdss/mdss_fb.c: In function 'mdss_fb_blank_unblank':
/mnt/packages/lineageos/kernel/alcatel/msm8916,CarlosArriagaCM/drivers/video/msm/mdss/mdss_fb.c:1463:12: error: invalid storage class for function 'mdss_fb_blank_sub'
 static int mdss_fb_blank_sub(int blank_mode, struct fb_info *info,
            ^
/mnt/packages/lineageos/kernel/alcatel/msm8916,CarlosArriagaCM/drivers/video/msm/mdss/mdss_fb.c:1463:1: warning: ISO C90 forbids mixed declarations and code [-Wdeclaration-after-statement]
error, forbidden warning: mdss_fb.c:1463
make[5]: *** [/mnt/packages/lineageos/kernel/alcatel/msm8916,CarlosArriagaCM/scripts/Makefile.build:308: drivers/video/msm/mdss/mdss_fb.o] Error 1
make[4]: *** [/mnt/packages/lineageos/kernel/alcatel/msm8916,CarlosArriagaCM/scripts/Makefile.build:455: drivers/video/msm/mdss] Error 2
make[3]: *** [/mnt/packages/lineageos/kernel/alcatel/msm8916,CarlosArriagaCM/scripts/Makefile.build:455: drivers/video/msm] Error 2
make[3]: *** Waiting for unfinished jobs....
  CC      drivers/usb/storage/usb.o
  CC      drivers/staging/prima/CORE/MAC/src/pe/lim/limStaHashApi.o
make[2]: *** [/mnt/packages/lineageos/kernel/alcatel/msm8916,CarlosArriagaCM/scripts/Makefile.build:455: drivers/video] Error 2
make[2]: *** Waiting for unfinished jobs....

--- a/drivers/video/msm/mdss/mdss_fb.c
+++ b/drivers/video/msm/mdss/mdss_fb.c
@@ -1455,6 +1455,8 @@ static int mdss_fb_blank_unblank(struct msm_fb_data_type *mfd)
                         */
                        mfd->allow_bl_update = false;
                }
+               mutex_unlock(&mfd->bl_lock);
+       }
        #endif
 error:
        return ret;

/#    _  __                 _   ___ _
/#   | |/ /___ _ _ _ _  ___| | | __(_)_ _____ ___
/#   | ' </ -_) '_| ' \/ -_) | | _|| \ \ / -_|_-<
/#   |_|\_\___|_| |_||_\___|_| |_| |_/_\_\___/__/
/#

/mnt/packages/lineageos/kernel/alcatel/msm8916,CarlosArriagaCM/lib/random32.c:179:50: error: expected ')' before numeric constant
 static DEFINE_TIMER(seed_timer, __prandom_timer, 0, 0);
                                                  ^

--- a/lib/random32.c
+++ b/lib/random32.c
@@ -38,6 +38,7 @@
 #include <linux/export.h>
 #include <linux/jiffies.h>
 #include <linux/random.h>
+#include <linux/sched.h>

 static DEFINE_PER_CPU(struct rnd_state, net_rand_state);
```